### PR TITLE
optional single chart path override

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   charts_dir:
     description: "The charts directory, defaults to `charts`"
     required: false
+  single_chart_path:
+    description: "Single chart directory if there is no desire to go over multiple charts"
+    required: false
   charts_url:
     description: "The GitHub Pages URL, defaults to `https://<OWNER>.github.io/<REPOSITORY>`"
     required: false
@@ -58,6 +61,8 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    OPTIONAL_SINGLE_CHART_PATH: ${{ inputs.single_chart_path }}
   args:
     - ${{ inputs.token }}
     - ${{ inputs.charts_dir }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -104,6 +104,11 @@ main() {
 }
 
 locate() {
+  if [[ ! -z "$OPTIONAL_SINGLE_CHART_PATH" ]]; then
+    CHARTS=("${OPTIONAL_SINGLE_CHART_PATH}")
+    echo "Found chart directory ${OPTIONAL_SINGLE_CHART_PATH}"
+    return
+  fi
   for dir in $(find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1); do
     if [[ -f "${dir}/Chart.yaml" ]]; then
       CHARTS+=("${dir}")


### PR DESCRIPTION
In a charts directory where there are multiple charts, it's not possible to pick just one. For example
```
./charts/app1
./charts/app2
./charts/app3
```
picking and releasing only `./charts/app2` is not an option because of the `find` limitations
```
find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1
```
passing `CHARTS_DIR` as `./charts` would list all three charts and passing `./charts/app2` would list all subdirs in `./charts/app2`.

This allows setting `single_chart_path` input to allow picking just `./charts/app2`.